### PR TITLE
Centralize configs

### DIFF
--- a/fms-certbot-deployer
+++ b/fms-certbot-deployer
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Configuration directory and files
-CONFIG_DIR="${HOME}/.fms-certbot-deployer"
+CONFIG_DIR="${HOME}/.fms-tools"
 CONFIG_FILE="${CONFIG_DIR}/fms-certbot-deployer.config"
 
 # Password encryption key (not secret but avoids plain text storage)

--- a/fms-restarter
+++ b/fms-restarter
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Configuration directory and files
-CONFIG_DIR="${HOME}/.fms-restarter"
+CONFIG_DIR="${HOME}/.fms-tools"
 CONFIG_FILE="${CONFIG_DIR}/fms-restarter.config"
 CLIENTS_LIST="${CONFIG_DIR}/fmsadmin-list-clients"
 FILES_LIST="${CONFIG_DIR}/fmsadmin-list-files"


### PR DESCRIPTION
## Summary
- store configuration files under `~/.fms-tools`

## Testing
- `bash -n fms-certbot-deployer`
- `bash -n fms-restarter`
- `shellcheck fms-certbot-deployer fms-restarter` (warnings expected)

------
https://chatgpt.com/codex/tasks/task_e_6862a4cfc3948329afce34c3e30a90b4