### PR TITLE
Fix blank lines in fms-restarter missing config message

### DIFF
--- a/fms-restarter
+++ b/fms-restarter
@@ -63,8 +63,6 @@ show_missing_config() {
   Example:
     $0 --configure
 EOF
-
-    echo >&2
 }
 
 
@@ -441,7 +439,6 @@ run_default() {
 }
 
 if [[ $# -eq 0 ]]; then
-    echo
     run_default > >(sed 's/^/  /') 2> >(sed 's/^/  /' >&2)
     status=$?
     echo


### PR DESCRIPTION
## Summary
- adjust `fms-restarter` so the missing configuration message only prints one prefixed blank line
- remove redundant blank line from the end of the message

## Testing
- `bash -n fms-restarter`
- `./fms-restarter`

------
https://chatgpt.com/codex/tasks/task_e_6862bd862164832982d542daa2b89f6e