### PR TITLE
Unify encryption key

### DIFF
--- a/fms-certbot-deployer
+++ b/fms-certbot-deployer
@@ -4,8 +4,9 @@
 CONFIG_DIR="${HOME}/.fms-tools"
 CONFIG_FILE="${CONFIG_DIR}/fms-tools.config"
 
-# Password encryption key (not secret but avoids plain text storage)
-ENCRYPT_KEY="fms-certbot-deployer"
+# Password encryption key shared across all fms-tools (not secret but avoids
+# plain text storage)
+ENCRYPT_KEY="fms-tools"
 
 # Track whether extra command output should be displayed
 VERBOSE=0

--- a/fms-restarter
+++ b/fms-restarter
@@ -10,8 +10,9 @@ CLOSE_LOG="${CONFIG_DIR}/fmsadmin-close-log"
 FILES_CLOSED_COUNT=0
 FILES_OPEN_COUNT=0
 RESTART_FLAG="${CONFIG_DIR}/fms-restart-needed"
-# Password encryption key (not secret but avoids plain text storage)
-ENCRYPT_KEY="fms-restarter"
+# Password encryption key shared across all fms-tools (not secret but avoids
+# plain text storage)
+ENCRYPT_KEY="fms-tools"
 
 # Track whether extra command output should be displayed
 VERBOSE=0


### PR DESCRIPTION
## Summary
- use "fms-tools" for ENCRYPT_KEY in both scripts
- document that the password encryption key is shared

## Testing
- `shellcheck fms-certbot-deployer fms-restarter`
- `./fms-certbot-deployer --help`
- `./fms-restarter --help`


------
https://chatgpt.com/codex/tasks/task_e_6863022c68ec8329848305aa9daf6f09