### PR TITLE
Fix initial output format in fms-restarter

### DIFF
--- a/fms-restarter
+++ b/fms-restarter
@@ -439,6 +439,7 @@ run_default() {
 }
 
 if [[ $# -eq 0 ]]; then
+    echo
     run_default > >(sed 's/^/  /') 2> >(sed 's/^/  /' >&2)
     status=$?
     echo


### PR DESCRIPTION
## Summary
- add an initial `echo` before running `run_default` so the default invocation begins with a blank line

## Testing
- `./fms-restarter 2>&1 | cat -n | head -n 12`

------
https://chatgpt.com/codex/tasks/task_e_686358d852ec8329a2ea2333cd611977